### PR TITLE
Fix - Agora faz trim da pesquisa e arruma bug de regex

### DIFF
--- a/.github/workflows/add-post.yaml
+++ b/.github/workflows/add-post.yaml
@@ -38,7 +38,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 18
-    - run: npm install puppeteer
+        cache: 'yarn'
+
+    - name: Installs puppeteer
+      run: yarn add puppeteer
 
     - name: Runs post script
       run: npm run addpost ${{ github.event.inputs.social }} ${{ github.event.inputs.tweetUrl }} -- --title="${{ github.event.inputs.title }}" --description="${{ github.event.inputs.description }}"
@@ -46,7 +49,6 @@ jobs:
     # Commit changes
     - name: Commit and push if changed
       run: |-
-        rm package-lock.json
         git config --global user.email "nickgabe@manager.com"
         git config --global user.name "Post Manager"
         git add -A

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,12 +21,15 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts --ignore-optional
+
+      - name: Build project
+        run: yarn build
 
       - name: Run Cypress tests
         uses: cypress-io/github-action@v5
         timeout-minutes: 5
         with:
           browser: chrome
-          start: yarn dev
+          start: yarn start
           wait-on: 'http://localhost:3000'

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.2",
     "prettier": "^2.8.8",
-    "puppeteer": "^19.11.1",
     "typescript-plugin-css-modules": "^5.0.1"
+  },
+  "optionalDependencies": {
+    "puppeteer": "^19.11.1"
   }
 }

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -10,7 +10,10 @@ export async function GET(req: Request) {
     return new Response(
       JSON.stringify(
         posts.filter((post) => {
-          return regex.test(post.full);
+          return (
+            regex.test(post.full) ||
+            post.full.toLowerCase().includes(search.toLowerCase())
+          );
         })
       )
     );

--- a/src/app/components/Search/Search.tsx
+++ b/src/app/components/Search/Search.tsx
@@ -14,14 +14,14 @@ export const Search = (props: SearchProps) => {
   );
 
   useEffect(() => {
-    debouncedSearch(value);
+    debouncedSearch(value.trim());
   }, [value, debouncedSearch, props]);
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
     setValue(newValue);
 
-    if (props.search === newValue) return props.setLoading(false);
+    if (props.search === newValue.trim()) return props.setLoading(false);
     props.setLoading(true);
   };
 

--- a/src/app/components/TextWithHighlight/TextWithHighlight.tsx
+++ b/src/app/components/TextWithHighlight/TextWithHighlight.tsx
@@ -1,13 +1,21 @@
 import { TextWithHighlightProps } from './TextTypes';
 
 export const TextWithHighlight = (props: TextWithHighlightProps) => {
+  if (!props.highlight) return <span>{props.text}</span>;
+
   return (
     <span
       dangerouslySetInnerHTML={{
-        __html: props.text.replaceAll(
-          new RegExp(props.highlight, 'ig'),
-          (match) => `<span class="text-primary"/>${match}</span>`
-        ),
+        __html: props.text
+          .toLowerCase()
+          .replaceAll(
+            props.highlight.toLowerCase(),
+            (match) => `<span class="text-primary"/>${match}</span>`
+          )
+          .replaceAll(
+            new RegExp(props.highlight, 'ig'),
+            (match) => `<span class="text-primary"/>${match}</span>`
+          ),
       }}
     />
   );

--- a/src/app/page.cy-e2e.tsx
+++ b/src/app/page.cy-e2e.tsx
@@ -14,11 +14,18 @@ describe('App', () => {
   });
 
   describe('Search', () => {
-    it('should be able to search for a post', () => {
-      cy.get('input').type('Tu usa git?');
+    describe('should be able to search for a post', () => {
+      it('using regex', () => {
+        cy.get('input').type('\\?$');
+        cy.get('span').contains('?');
+        cy.get('a').should('have.attr', 'href');
+      });
 
-      cy.get('span').contains('Tu usa git?');
-      cy.get('a').should('have.attr', 'href');
+      it('using literal string', () => {
+        cy.get('input').type('Tu usa git?');
+        cy.get('span').contains(/Tu usa git?/i);
+        cy.get('a').should('have.attr', 'href');
+      });
     });
 
     it('should copy link successfully', async () => {


### PR DESCRIPTION
### Closes #23 

## O que este PR faz?
Previamente, se você inserisse um caractere especial de regex na pesquisa, ele trataria como regex e não literal, então alguns posts acabavam não tendo o highlight correto. Como por exemplo "Tu usa git?" tratava como se git fosse opcional, ao invés da string literal.

Agora ele pesquisa tanto usando regex quando string literal, e retorna resultados baseados em ambos.

Adicionei esse post de exemplo pra uma situação onde valida regex & literal.
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/42651514/e80d2031-3afa-4ed7-affe-dcd8ec7d95eb)
ele trata como regex e aceita o "você usa gi", e ao mesmo tempo trata como literal e aceita o "você usa git?"