### PR TITLE
Altera o regex para não re-highlitar texto

### DIFF
--- a/src/app/components/TextWithHighlight/TextWithHighlight.tsx
+++ b/src/app/components/TextWithHighlight/TextWithHighlight.tsx
@@ -13,7 +13,11 @@ export const TextWithHighlight = (props: TextWithHighlightProps) => {
             (match) => `<span class="text-primary"/>${match}</span>`
           )
           .replaceAll(
-            new RegExp(props.highlight, 'ig'),
+            new RegExp(
+              // esse regex maluco seleciona apenas highlights que ainda não foram selecionados
+              `\b${props.highlight}\b(?!(?:(?!<\/?span)[^<])*<\/span>)`,
+              'ig'
+            ),
             (match) => `<span class="text-primary"/>${match}</span>`
           ),
       }}


### PR DESCRIPTION
<!-- Adicione aqui a linking word e o número da issue, se aplicável. -->
Closes #38 

## O que este PR faz?
Faz com que a própria tag de highlight não sofra highlight, e também previne duplicidade de dois highlights.

## Sumário das alterações
- Altera o regex, ele agora faz highlight somente na pesquisa que estiver fora de uma tag span
<!-- O que mudou no projeto? Exemplo: Modifiquei a cor do texto no botão para melhor contraste e acessibilidade -->

## Mídia
<!-- Insira aqui screenshots de antes e depois, ou somente das alterações feitas -->
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/42651514/11bf85e2-f92a-4673-b3d2-25061f850fe9)
