### PR TITLE
Adiciona página na query, muda url conforme pesquisa/página

### DIFF
--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+  interface Chainable {
+    clipboardContains(value: string): Chainable<void>;
+  }
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -35,3 +35,11 @@
 //     }
 //   }
 // }
+
+Cypress.Commands.add('clipboardContains' as any, (value) => {
+  cy.window().then((win) => {
+    win.navigator.clipboard.readText().then((text) => {
+      expect(text).to.eq(value);
+    });
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -9,7 +9,6 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 //
-//
 // -- This is a parent command --
 // Cypress.Commands.add('login', (email, password) => { ... })
 //
@@ -25,16 +24,6 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 //
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
 
 Cypress.Commands.add('clipboardContains' as any, (value) => {
   cy.window().then((win) => {

--- a/public/extras/bg-wave.svg
+++ b/public/extras/bg-wave.svg
@@ -1,3 +1,3 @@
-<svg width="1440" height="302" viewBox="0 0 1440 302" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100" height="21" viewBox="0 0 1440 302" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0L60 28C120 57 240 115 360 151C480 187 600 201 720 165C840 129 960 43 1080 43C1200 43 1320 129 1380 172L1440 216V302H1380C1320 302 1200 302 1080 302C960 302 840 302 720 302C600 302 480 302 360 302C240 302 120 302 60 302H0V0Z" fill="#4D4577"/>
 </svg>

--- a/src/app/components/Background/Background.tsx
+++ b/src/app/components/Background/Background.tsx
@@ -4,7 +4,7 @@ export const Background = () => {
   return (
     <div className="w-full h-full fixed top-[300px] -z-10">
       <Image
-        className="w-full"
+        className="w-full select-none"
         src="/extras/bg-wave.svg"
         alt=""
         width={100}

--- a/src/app/components/Background/Background.tsx
+++ b/src/app/components/Background/Background.tsx
@@ -7,8 +7,8 @@ export const Background = () => {
         className="w-full"
         src="/extras/bg-wave.svg"
         alt=""
-        width={1440}
-        height={368}
+        width={100}
+        height={21}
       />
       <div className="h-full w-full bg-brightPurple"></div>
     </div>

--- a/src/app/components/GithubCorner/octocatAnimation.module.css
+++ b/src/app/components/GithubCorner/octocatAnimation.module.css
@@ -1,4 +1,4 @@
-.githubCorner svg {
+.githubCorner {
   cursor: pointer;
   clip-path: polygon(0 0, 100% 0, 100% 100%);
 }

--- a/src/app/components/Posts/PostPages.tsx
+++ b/src/app/components/Posts/PostPages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ArrowNext from '@public/icons/arrow-right-square.svg';
 import ArrowPrev from '@public/icons/arrow-left-square.svg';
 import { Pagination } from 'antd';
@@ -9,17 +9,23 @@ import { PostPagesProps } from './postsTypes';
 const postsPerPage = 9;
 
 export const PostPages = (props: PostPagesProps) => {
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = props.pageHooks;
   const [posts, setPosts] = useState<Post[]>([]);
 
+  const totalPages = useMemo(
+    () => Math.ceil(props.posts.length / postsPerPage),
+    [props.posts.length]
+  );
+
   useEffect(() => {
-    setPosts(
-      props.posts.slice(
-        (currentPage - 1) * postsPerPage,
-        currentPage * postsPerPage
-      )
+    if (currentPage > totalPages) setCurrentPage(totalPages);
+
+    const slicedPosts = props.posts.slice(
+      (currentPage - 1) * postsPerPage,
+      currentPage * postsPerPage
     );
-  }, [currentPage, props.posts]);
+    setPosts(slicedPosts);
+  }, [currentPage, props.posts, setCurrentPage, totalPages]);
 
   return (
     <>

--- a/src/app/components/Posts/Posts.tsx
+++ b/src/app/components/Posts/Posts.tsx
@@ -25,5 +25,11 @@ export const Posts = (props: PostsProps) => {
   if (loading) return <Loading />;
   if (posts.length === 0) return <NoPostsFound />;
 
-  return <PostPages posts={posts} search={props.search} />;
+  return (
+    <PostPages
+      posts={posts}
+      search={props.search}
+      pageHooks={props.pageHooks}
+    />
+  );
 };

--- a/src/app/components/Posts/postsTypes.d.ts
+++ b/src/app/components/Posts/postsTypes.d.ts
@@ -5,9 +5,11 @@ export type PostsProps = {
   search: string;
   loading: boolean;
   setLoading: Dispatch<SetStateAction<boolean>>;
+  pageHooks: [number, Dispatch<SetStateAction<number>>];
 };
 
 export type PostPagesProps = {
   posts: Post[];
   search: string;
+  pageHooks: [number, Dispatch<SetStateAction<number>>];
 };

--- a/src/app/components/Search/SearchButtons.tsx
+++ b/src/app/components/Search/SearchButtons.tsx
@@ -5,11 +5,7 @@ import { SearchButtonsProps } from './SearchTypes';
 
 export const SearchButtons = (props: SearchButtonsProps) => {
   const copyLink = () => {
-    const params = new URLSearchParams({
-      search: props.value,
-    });
-    const link = `${window.origin}?${params.toString()}`;
-    navigator.clipboard.writeText(link);
+    navigator.clipboard.writeText(window.location.href);
     message.success('Link copiado para a área de transferência!');
   };
 

--- a/src/app/page.cy-e2e.tsx
+++ b/src/app/page.cy-e2e.tsx
@@ -5,6 +5,7 @@ describe('App', () => {
     cy.get('span').contains('CENTRAL');
     cy.get('span').contains('nick gabe');
     cy.get('input').should('have.attr', 'placeholder', 'Pesquise um tema');
+    cy.url().should('be.equal', 'http://localhost:3000/');
   });
 
   describe('Posts', () => {
@@ -15,6 +16,8 @@ describe('App', () => {
 
   describe('Search', () => {
     describe('should be able to search for a post', () => {
+      beforeEach(() => cy.visit('/'));
+
       it('using regex', () => {
         cy.get('input').type('\\?$');
         cy.get('span').contains('?');
@@ -28,16 +31,34 @@ describe('App', () => {
       });
     });
 
-    it('should copy link successfully', async () => {
-      cy.get('input').type('Tu usa git?');
+    describe('should copy link successfully', async () => {
+      beforeEach(() => cy.visit('/'));
 
-      cy.get('button[data-test-id="copy-link"]').click();
-      cy.get('span').contains('Link copiado para a área de transferência!');
+      it('with search', () => {
+        cy.get('input').type('opa dev');
+
+        cy.get('span').contains('opa dev');
+        cy.get('button[data-test-id="copy-link"]').click();
+
+        cy.get('span').contains('Link copiado para a área de transferência!');
+        cy.clipboardContains('http://localhost:3000/?search=opa+dev');
+      });
+
+      it('with search and page', () => {
+        cy.get('input').type('op');
+
+        cy.get('.ant-pagination-next').click();
+        cy.get('span').contains('op');
+
+        cy.get('button[data-test-id="copy-link"]').click();
+        cy.get('span').contains('Link copiado para a área de transferência!');
+        cy.clipboardContains('http://localhost:3000/?page=2&search=op');
+      });
     });
   });
 
   it('should be redirected when github corner is clicked', () => {
-    cy.get('a:first-of-type').click();
+    cy.get('a').click({ force: true });
     cy.url().should(
       'be.equal',
       'https://github.com/nick-gabe/central-nickgabe'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,15 +17,17 @@ export default function Home({ searchParams }: { searchParams: Params }) {
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(0);
 
-  const updateQuery = useCallback((query: URLSearchParams) => {
+  const updateQuery = useCallback((query = new URLSearchParams()) => {
     const { origin } = window;
-    const params = '?' + query.toString();
+    const queryStr = query.toString();
+    const params = queryStr ? '?' + queryStr : '';
 
     window.history.replaceState({}, '', origin + params);
   }, []);
 
   useEffect(() => {
-    if (page === 0) return setPage(Number(searchParams.page || 1));
+    const pageParam = Number(searchParams.page);
+    if (page === 0 && pageParam > 0) return setPage(pageParam);
     setPage(1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search, searchParams.page]);
@@ -35,7 +37,7 @@ export default function Home({ searchParams }: { searchParams: Params }) {
     if (page > 1) params.page = page.toString();
     if (search) params.search = search;
 
-    if (Object.keys(params).length === 0) return;
+    if (Object.keys(params).length === 0 && page > 1) return;
 
     const URLParams = new URLSearchParams(params);
     updateQuery(URLParams);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,57 @@
 'use client';
 
+import { useCallback, useEffect, useState } from 'react';
 import { Background } from './components/Background/Background';
 import { GithubCorner } from '@components/GithubCorner/GithubCorner';
 import { Posts } from './components/Posts/Posts';
 import { Search } from './components/Search/Search';
 import { Title } from './components/Title/Title';
-import { useState } from 'react';
 
-export default function Home({
-  searchParams,
-}: {
-  searchParams: Record<string, string>;
-}) {
+type Params = {
+  search: string;
+  page: string;
+};
+
+export default function Home({ searchParams }: { searchParams: Params }) {
   const [search, setSearch] = useState(searchParams.search || '');
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+
+  const updateQuery = useCallback((query: URLSearchParams) => {
+    const { origin } = window;
+    const params = '?' + query.toString();
+
+    window.history.replaceState({}, '', origin + params);
+  }, []);
+
+  useEffect(() => {
+    if (page === 0) return setPage(Number(searchParams.page || 1));
+    setPage(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, searchParams.page]);
+
+  useEffect(() => {
+    const params: Partial<Params> = {};
+    if (page > 1) params.page = page.toString();
+    if (search) params.search = search;
+
+    if (Object.keys(params).length === 0) return;
+
+    const URLParams = new URLSearchParams(params);
+    updateQuery(URLParams);
+  }, [page, search, updateQuery]);
 
   return (
     <main className="flex flex-col items-center min-h-screen sm:justify-center my-20">
       <GithubCorner />
       <Title />
       <Search search={search} setSearch={setSearch} setLoading={setLoading} />
-      <Posts search={search} loading={loading} setLoading={setLoading} />
+      <Posts
+        search={search}
+        loading={loading}
+        setLoading={setLoading}
+        pageHooks={[page, setPage]}
+      />
       <Background />
     </main>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts", "cypress/support/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
<!-- Adicione aqui a linking word e o número da issue, se aplicável. -->
Closes #36 
Closes #35 

## O que este PR faz?
Agora conforme o usuário digita algo na barra de pesquisas ou muda de página, essa mudança é adicionada ao url atual.

## Sumário das alterações
<!-- O que mudou no projeto? Exemplo: Modifiquei a cor do texto no botão para melhor contraste e acessibilidade -->
- Pesquisa e Página aparecem na query
- Página também é levada em conta ao copiar o link da pesquisa
- Caso a página fornecida na query seja maior que a quantidade de posts (usuário mudou manualmente), ele leva em conta como se fosse a última página
- Caso a página fornecida seja menor que 0, ele remove a url e considera como se fosse a primeira página
- Diminui o tamanho do background para um melhor desempenho em FCP
- Adiciona clip path no ícone do github corner
- Cria testes para a query

## Mídia
<!-- Insira aqui screenshots de antes e depois, ou somente das alterações feitas -->
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/42651514/466acc57-1ab2-4ce7-9a37-5098a18ba9d2)
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/42651514/9cc1d7f7-626b-4702-bc76-7c6ee509f13b)
