### PR TITLE
fix: show search in description

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -18,6 +18,8 @@ export async function GET(req: Request) {
       .map((post) => {
         if (!search) return post;
         const fullTextWithoutTitle = post.full.replace(post.title, '');
+        if (!fullTextWithoutTitle.toLowerCase().includes(search.toLowerCase()))
+          return post;
 
         const allWords = fullTextWithoutTitle.split(' ').map((word) => {
           if (word.includes('\n')) {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -9,18 +9,17 @@ export async function GET(req: Request) {
 
     const includesSearch = (text: string): boolean => {
       return (
-        regex.test(text) ||
-        text.toLowerCase().includes(search.toLowerCase())
+        regex.test(text) || text.toLowerCase().includes(search.toLowerCase())
       );
-    }
-    
+    };
+
     const filteredPosts = posts
       .filter((post) => includesSearch(post.full))
       // update description
       .map((post) => {
         if (!search) return post;
         const fullTextWithoutTitle = post.full.replace(post.title, '');
-        if (!includesSearch(fullTextWithoutTitle)) return post
+        if (!includesSearch(fullTextWithoutTitle)) return post;
 
         const allWords = fullTextWithoutTitle.split(' ').map((word) => {
           if (word.includes('\n')) {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -29,10 +29,12 @@ export async function GET(req: Request) {
           return word;
         });
 
-        const start = index - 2;
         const index = allWords.findIndex((word) => includesSearch(word));
+        if (index === -1) return post;
+        const after = allWords.slice(index).join(' ').length;
+        const start = after > 100 ? index - 2 : index - 6; // more words before if after is too big
         const end = allWords.length - 1;
-        let description = allWords.slice(start, end).join(' ');
+        let description = allWords.slice(start < 0 ? 0 : start, end).join(' ');
 
         description =
           description.length > 100 ? description.slice(0, 100) : description;

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -17,8 +17,9 @@ export async function GET(req: Request) {
       // update description
       .map((post) => {
         if (!search) return post;
+        const fullTextWithoutTitle = post.full.replace(post.title, '');
 
-        const allWords = post.full.split(' ').map((word) => {
+        const allWords = fullTextWithoutTitle.split(' ').map((word) => {
           if (word.includes('\n')) {
             const split = word.split('\n');
             return split[split.length - 1] + '\n';

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -29,8 +29,8 @@ export async function GET(req: Request) {
           return word;
         });
 
-        const index = allWords.findIndex((word) => regex.test(word));
         const start = index - 2;
+        const index = allWords.findIndex((word) => includesSearch(word));
         const end = allWords.length - 1;
         let description = allWords.slice(start, end).join(' ');
 

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -7,19 +7,20 @@ export async function GET(req: Request) {
   try {
     const regex = new RegExp(search, 'ig');
 
+    const includesSearch = (text: string): boolean => {
+      return (
+        regex.test(text) ||
+        text.toLowerCase().includes(search.toLowerCase())
+      );
+    }
+    
     const filteredPosts = posts
-      .filter((post) => {
-        return (
-          regex.test(post.full) ||
-          post.full.toLowerCase().includes(search.toLowerCase())
-        );
-      })
+      .filter((post) => includesSearch(post.full))
       // update description
       .map((post) => {
         if (!search) return post;
         const fullTextWithoutTitle = post.full.replace(post.title, '');
-        if (!fullTextWithoutTitle.toLowerCase().includes(search.toLowerCase()))
-          return post;
+        if (!includesSearch(fullTextWithoutTitle)) return post
 
         const allWords = fullTextWithoutTitle.split(' ').map((word) => {
           if (word.includes('\n')) {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -7,16 +7,44 @@ export async function GET(req: Request) {
   try {
     const regex = new RegExp(search, 'ig');
 
-    return new Response(
-      JSON.stringify(
-        posts.filter((post) => {
-          return (
-            regex.test(post.full) ||
-            post.full.toLowerCase().includes(search.toLowerCase())
-          );
-        })
-      )
-    );
+    const filteredPosts = posts
+      .filter((post) => {
+        return (
+          regex.test(post.full) ||
+          post.full.toLowerCase().includes(search.toLowerCase())
+        );
+      })
+      // update description
+      .map((post) => {
+        if (!search) return post;
+
+        const allWords = post.full.split(' ').map((word) => {
+          if (word.includes('\n')) {
+            const split = word.split('\n');
+            return split[split.length - 1] + '\n';
+          }
+          return word;
+        });
+
+        const index = allWords.findIndex((word) => regex.test(word));
+        const start = index - 2;
+        const end = allWords.length - 1;
+        let description = allWords.slice(start, end).join(' ');
+
+        description =
+          description.length > 100 ? description.slice(0, 100) : description;
+
+        const firstWord = description.split(' ')[0];
+        if (firstWord !== post.description.split(' ')[0])
+          description = '...' + description;
+
+        return {
+          ...post,
+          description,
+        };
+      });
+
+    return new Response(JSON.stringify(filteredPosts));
   } catch (error) {
     return new Response('[]');
   }

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,5 +1,7 @@
 import posts from '@public/posts.json';
 
+const emojiRegex = new RegExp('^[\\n\\s\\p{Emoji}]', 'u');
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const search = searchParams.get('search') || '';
@@ -40,7 +42,15 @@ export async function GET(req: Request) {
           description.length > 100 ? description.slice(0, 100) : description;
 
         const firstWord = description.split(' ')[0];
-        if (firstWord !== post.description.split(' ')[0])
+        if (
+          index > 0 &&
+          // verify if first word is a new line, an emoji or whitespace
+          !(
+            firstWord.match(emojiRegex) ||
+            firstWord === '\n' ||
+            firstWord === ' '
+          )
+        )
           description = '...' + description;
 
         return {


### PR DESCRIPTION
Solves #37 
<!-- Adicione aqui a linking word e o número da issue, se aplicável. -->
## O que este PR faz?
Ao procurar por um post, a descrição não estava mudando. A descrição estática estava sendo usada e as vezes não incluía o termo buscado que estava presente na propriedade `full`.
## Sumário das alterações
<!-- O que mudou no projeto? Exemplo: Modifiquei a cor do texto no botão para melhor contraste e acessibilidade -->
Agora na rota `posts` a descrição é atualizada de acordo com a pesquisa, fazendo uso da propriedade `full` do post e formatando de acordo.
## Mídia
<!-- Insira aqui screenshots de antes e depois, ou somente das alterações feitas -->
Antes das alterações:
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/76636791/b6ce820c-3064-4017-817d-0a4713f5fe83)
Depois das alterações:
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/76636791/4d296ef6-cd63-4b5a-aa67-c80f979f7dac)