### PR TITLE
fix: twitter fetch including retweets (#52)

### DIFF
--- a/scripts/twitter/fetchTweet.js
+++ b/scripts/twitter/fetchTweet.js
@@ -48,6 +48,13 @@ const fetchTweet = async (url, params) => {
         const elements = Array.from(
           div.querySelectorAll('[data-testid=tweetText]>*')
         )
+          .filter((item) => {
+            const roleLink =
+              item?.parentElement?.parentElement?.parentElement?.parentElement?.getAttribute(
+                'role'
+              );
+            return roleLink !== 'link';
+          })
           .map((item) => item.alt || item.textContent)
           .join('');
 
@@ -67,12 +74,12 @@ const fetchTweet = async (url, params) => {
   const contentType =
     isVideo || threadTweets.length > 1 ? 'text' : isImage || isLink;
 
-  const defaultImage = "https://pbs.twimg.com/profile_images";
-  
+  const defaultImage = 'https://pbs.twimg.com/profile_images';
+
   return {
     url,
     date,
-    image: image.startsWith(defaultImage) ? "" : image,
+    image: image.startsWith(defaultImage) ? '' : image,
     type: contentType,
     full: threadAsText,
     title: params.title || firstTweet.slice(0, sliceEnd),


### PR DESCRIPTION
<!-- Adicione aqui a linking word e o número da issue, se aplicável. -->
fixes #52 
## O que este PR faz?
Resolve o problema de os retweets serem adicionados juntamente com o tweet.

## Sumário das alterações
<!-- O que mudou no projeto? Exemplo: Modifiquei a cor do texto no botão para melhor contraste e acessibilidade -->
Adicionei um filtro para verificar se o item do array formado a partir de tweetText possui um parente distante com o atributo role=link. Foi a solução que encontrei, vai resolver o problema por enquanto. O código foi testado localmente, como mostra a mídia indexada nesse pull request.

## Mídia
<!-- Insira aqui screenshots de antes e depois, ou somente das alterações feitas -->
![image](https://github.com/Nick-Gabe/central-nickgabe/assets/76636791/ccfaaacc-ca65-4c12-bae5-bbe4df262c10)
