### PR TITLE
fix: fixes clipboard e2e bug, removes regex search

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -7,12 +7,8 @@ export async function GET(req: Request) {
   const search = searchParams.get('search') || '';
 
   try {
-    const regex = new RegExp(search, 'ig');
-
     const includesSearch = (text: string): boolean => {
-      return (
-        regex.test(text) || text.toLowerCase().includes(search.toLowerCase())
-      );
+      return text.toLowerCase().includes(search.toLowerCase());
     };
 
     const filteredPosts = posts

--- a/src/app/page.cy-e2e.tsx
+++ b/src/app/page.cy-e2e.tsx
@@ -1,3 +1,11 @@
+Cypress.automation('remote:debugger:protocol', {
+  command: 'Browser.grantPermissions',
+  params: {
+    origin: window.location.origin,
+    permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+  },
+});
+
 describe('App', () => {
   beforeEach(() => cy.visit('/'));
 
@@ -17,12 +25,6 @@ describe('App', () => {
   describe('Search', () => {
     describe('should be able to search for a post', () => {
       beforeEach(() => cy.visit('/'));
-
-      it('using regex', () => {
-        cy.get('input').type('\\?$');
-        cy.get('span').contains('?');
-        cy.get('a').should('have.attr', 'href');
-      });
 
       it('using literal string', () => {
         cy.get('input').type('Tu usa git?');


### PR DESCRIPTION
## Closes #58 #60 
<!-- Adicione aqui a linking word e o número da issue, se aplicável. -->

## O que este PR faz?
Remove o regex de pesquisas, e arruma o bug no qual o cypress não conseguia testar o clipboard.

## Sumário das alterações
<!-- O que mudou no projeto? Exemplo: Modifiquei a cor do texto no botão para melhor contraste e acessibilidade -->

## Mídia
<!-- Insira aqui screenshots de antes e depois, ou somente das alterações feitas -->
